### PR TITLE
Quote field to correctly interpret comma

### DIFF
--- a/codelists/dataType.csv
+++ b/codelists/dataType.csv
@@ -1,6 +1,6 @@
-Category,Code,Title_en,Description_en,Source
+Category,Code,Title_en,Description_en
 ,string,String,The requirement response must be of type string
 ,date-time,Date-time,The requirement response must be of type date-time (ISO8601)
-,number,Number,The requirement response must be of type number, i.e. a floating point or whole number
+,number,Number,"The requirement response must be of type number, i.e. a floating point or whole number"
 ,integer,Integer,The requirement response must be of type integer
 ,boolean,Boolean,The requirement response must be of type boolean

--- a/codelists/relatesTo.csv
+++ b/codelists/relatesTo.csv
@@ -1,3 +1,3 @@
-Category,Code,Title_en,Description_en,Source
+Category,Code,Title_en,Description_en
 ,tenderer,Tenderer,The criterion evaluates or assesses a tenderer
 ,item,Item,The criterion evaluates or assesses an item

--- a/codelists/responseSource.csv
+++ b/codelists/responseSource.csv
@@ -1,4 +1,4 @@
-Category,Code,Title_en,Description_en,Source
+Category,Code,Title_en,Description_en
 ,tenderer,Tenderer,The response should be provided by the tenderer 
 ,buyer,Buyer,The response should be provided by the buyer
 ,procuringEntity,Procuring entity,The response should be provided by the procuring entity


### PR DESCRIPTION
Remove extra Source column from codelist files. Add end-of-file newlines.