### PR TITLE
Allow boolean values in expectedValue and value

### DIFF
--- a/release-schema.json
+++ b/release-schema.json
@@ -176,6 +176,7 @@
             "string",
             "integer",
             "number",
+            "boolean",
             "null"
           ]
         },
@@ -241,6 +242,7 @@
             "string",
             "integer",
             "number",
+            "boolean",
             "null"
           ]
         },


### PR DESCRIPTION
[datatype.csv](https://github.com/open-contracting-extensions/ocds_requirements_extension/blob/master/codelists/dataType.csv) permits requirements to specify that a response must be a boolean value, however `expectedValue` and `value` did not include boolean as a permitted type.