### PR TITLE
add Criterion.relatedLots field and update changelog in README.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ## Changelog
 
+### Unreleased
+
+* Add `Criterion.relatedLots` field.
+
+This extension was originally discussed in <https://github.com/open-contracting/ocds-extensions/issues/76>.
+
 ### 2020-06-04
 
 * Review normative and non-normative words.

--- a/README.md
+++ b/README.md
@@ -193,8 +193,6 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 * Add `Criterion.relatedLots` field.
 
-This extension was originally discussed in <https://github.com/open-contracting/ocds-extensions/issues/76>.
-
 ### 2020-06-04
 
 * Review normative and non-normative words.

--- a/release-schema.json
+++ b/release-schema.json
@@ -77,7 +77,7 @@
         },
         "relatedLots": {
           "title": " Related lot(s)",
-          "description": "If this criterion relates to one or more specific lots, provide the identifier(s) of the related lot(s) here.",
+          "description": "The identifiers of related lots that this criterion applies to.",
           "type": [
             "array",
             "null"

--- a/release-schema.json
+++ b/release-schema.json
@@ -75,6 +75,22 @@
           ],
           "minLength": 1
         },
+        "relatedLots": {
+          "title": " Related lot(s)",
+          "description": "If this criterion relates to one or more specific lots, provide the identifier(s) of the related lot(s) here.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string"
+            ],
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
         "requirementGroups": {
           "title": "Requirement groups",
           "description": "A list of requirement groups for this Criterion. A criterion is satisfied by one or more requirement groups being met. A requirement group is met when all requirements in the group are satisfied.",

--- a/release-schema.json
+++ b/release-schema.json
@@ -76,7 +76,7 @@
           "minLength": 1
         },
         "relatedLots": {
-          "title": " Related lot(s)",
+          "title": "Related lot(s)",
           "description": "The identifiers of related lots that this criterion applies to.",
           "type": [
             "array",

--- a/release-schema.json
+++ b/release-schema.json
@@ -77,7 +77,7 @@
         },
         "relatedLots": {
           "title": "Related lot(s)",
-          "description": "The identifiers of related lots that this criterion applies to.",
+          "description": "The identifiers of the lots to which this criterion applies.",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
in the description I've copied from the relatedLots descriptions in the lots extension. But these read as directed to the publisher which goes against the schema style guide. An alternative could be "The identifiers of related lots that this criterion applies to." which is in more of a neutral voice.